### PR TITLE
feat: implement classes and instructors pages with client-side filtering

### DIFF
--- a/src/app/classes/layout.tsx
+++ b/src/app/classes/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Outdoor Fitness Classes | SmileFit",
+  description:
+    "Browse outdoor fitness classes in Italian cities. Find yoga, HIIT, pilates, running, boxing and more with certified instructors in Milan, Rome, Florence, Turin, and Bologna.",
+  openGraph: {
+    title: "Outdoor Fitness Classes | SmileFit",
+    description:
+      "Browse outdoor fitness classes in Italian cities. Find yoga, HIIT, pilates, running, boxing and more with certified instructors.",
+  },
+}
+
+export default function ClassesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/classes/page.tsx
+++ b/src/app/classes/page.tsx
@@ -1,10 +1,194 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { PageHeader } from "@/components/sections/page-header"
+import { ClassCard } from "@/components/cards/class-card"
+import { CTABanner } from "@/components/sections/cta-banner"
+import { classes, siteContent, siteConfig } from "@/lib/data"
+
 export default function ClassesPage() {
+  const [searchQuery, setSearchQuery] = useState("")
+  const [selectedCategory, setSelectedCategory] = useState<string>("all")
+  const [selectedCity, setSelectedCity] = useState<string>("all")
+  const [sortBy, setSortBy] = useState<string>("default")
+
+  const filteredClasses = useMemo(() => {
+    let result = [...classes]
+
+    // Filter by search query
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      result = result.filter(
+        (c) =>
+          c.title.toLowerCase().includes(query) ||
+          c.instructor.toLowerCase().includes(query) ||
+          c.location.toLowerCase().includes(query) ||
+          c.category.toLowerCase().includes(query)
+      )
+    }
+
+    // Filter by category
+    if (selectedCategory !== "all") {
+      result = result.filter((c) => c.category === selectedCategory)
+    }
+
+    // Filter by city
+    if (selectedCity !== "all") {
+      result = result.filter((c) => c.city === selectedCity)
+    }
+
+    // Sort
+    if (sortBy === "price-low") {
+      result.sort((a, b) => a.price - b.price)
+    } else if (sortBy === "price-high") {
+      result.sort((a, b) => b.price - a.price)
+    } else if (sortBy === "name") {
+      result.sort((a, b) => a.title.localeCompare(b.title))
+    }
+
+    return result
+  }, [searchQuery, selectedCategory, selectedCity, sortBy])
+
+  const clearFilters = () => {
+    setSearchQuery("")
+    setSelectedCategory("all")
+    setSelectedCity("all")
+    setSortBy("default")
+  }
+
+  const hasActiveFilters =
+    searchQuery || selectedCategory !== "all" || selectedCity !== "all"
+
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-4xl font-bold mb-4">Classes</h1>
-      <p className="text-muted-foreground">
-        Coming soon - Issue #6: Classes + Instructors Pages
-      </p>
-    </div>
+    <>
+      <PageHeader
+        title="Outdoor Fitness Classes"
+        subtitle="Find the perfect class for your fitness journey. Filter by category, location, or search for specific classes."
+      />
+
+      {/* Filters Section */}
+      <section className="py-8 border-b">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-4">
+            {/* Search and Filters Row */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {/* Search Input */}
+              <div className="relative sm:col-span-2 lg:col-span-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search classes..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+
+              {/* Category Filter */}
+              <Select
+                value={selectedCategory}
+                onValueChange={setSelectedCategory}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Categories</SelectItem>
+                  {siteConfig.categories.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {category}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* City Filter */}
+              <Select value={selectedCity} onValueChange={setSelectedCity}>
+                <SelectTrigger>
+                  <SelectValue placeholder="City" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Cities</SelectItem>
+                  {siteConfig.cities.map((city) => (
+                    <SelectItem key={city} value={city}>
+                      {city}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Sort */}
+              <Select value={sortBy} onValueChange={setSortBy}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Sort by" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default</SelectItem>
+                  <SelectItem value="price-low">Price: Low to High</SelectItem>
+                  <SelectItem value="price-high">Price: High to Low</SelectItem>
+                  <SelectItem value="name">Name: A to Z</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Results Count and Clear Filters */}
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Showing {filteredClasses.length} of {classes.length} classes
+              </p>
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="text-sm text-primary hover:underline"
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Classes Grid */}
+      <section className="py-12 sm:py-16">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          {filteredClasses.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredClasses.map((classItem) => (
+                <ClassCard key={classItem.id} classItem={classItem} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <p className="text-lg text-muted-foreground mb-4">
+                No classes found matching your criteria.
+              </p>
+              <button
+                onClick={clearFilters}
+                className="text-primary hover:underline"
+              >
+                Clear filters and show all classes
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* CTA Banner */}
+      <CTABanner
+        title={siteContent.ctaBanners.classes.title}
+        subtitle={siteContent.ctaBanners.classes.subtitle}
+        primaryCTA={siteContent.ctaBanners.classes.primaryCTA}
+        variant="gradient"
+      />
+    </>
   )
 }

--- a/src/app/instructors/layout.tsx
+++ b/src/app/instructors/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Meet Our Instructors | SmileFit",
+  description:
+    "Meet our certified fitness instructors. Expert trainers specializing in yoga, HIIT, pilates, running, boxing, and more across Italian cities.",
+  openGraph: {
+    title: "Meet Our Instructors | SmileFit",
+    description:
+      "Meet our certified fitness instructors. Expert trainers specializing in yoga, HIIT, pilates, running, boxing, and more.",
+  },
+}
+
+export default function InstructorsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/instructors/page.tsx
+++ b/src/app/instructors/page.tsx
@@ -1,10 +1,153 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { PageHeader } from "@/components/sections/page-header"
+import { InstructorCard } from "@/components/cards/instructor-card"
+import { CTABanner } from "@/components/sections/cta-banner"
+import { instructors, siteContent, siteConfig } from "@/lib/data"
+
 export default function InstructorsPage() {
+  const [searchQuery, setSearchQuery] = useState("")
+  const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([])
+
+  const filteredInstructors = useMemo(() => {
+    let result = [...instructors]
+
+    // Filter by search query
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      result = result.filter(
+        (instructor) =>
+          instructor.name.toLowerCase().includes(query) ||
+          instructor.bio.toLowerCase().includes(query) ||
+          instructor.specialties.some((s) => s.toLowerCase().includes(query))
+      )
+    }
+
+    // Filter by selected specialties
+    if (selectedSpecialties.length > 0) {
+      result = result.filter((instructor) =>
+        selectedSpecialties.some((specialty) =>
+          instructor.specialties.includes(specialty)
+        )
+      )
+    }
+
+    return result
+  }, [searchQuery, selectedSpecialties])
+
+  const toggleSpecialty = (specialty: string) => {
+    setSelectedSpecialties((prev) =>
+      prev.includes(specialty)
+        ? prev.filter((s) => s !== specialty)
+        : [...prev, specialty]
+    )
+  }
+
+  const clearFilters = () => {
+    setSearchQuery("")
+    setSelectedSpecialties([])
+  }
+
+  const hasActiveFilters = searchQuery || selectedSpecialties.length > 0
+
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-4xl font-bold mb-4">Instructors</h1>
-      <p className="text-muted-foreground">
-        Coming soon - Issue #6: Classes + Instructors Pages
-      </p>
-    </div>
+    <>
+      <PageHeader
+        title="Meet Our Instructors"
+        subtitle="Our certified fitness professionals are passionate about helping you achieve your goals. Find the perfect instructor for your fitness journey."
+      />
+
+      {/* Filters Section */}
+      <section className="py-8 border-b">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-6">
+            {/* Search Input */}
+            <div className="relative max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search instructors..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            {/* Specialty Tags */}
+            <div className="space-y-3">
+              <p className="text-sm font-medium">Filter by specialty:</p>
+              <div className="flex flex-wrap gap-2">
+                {siteConfig.categories.map((specialty) => (
+                  <Badge
+                    key={specialty}
+                    variant={
+                      selectedSpecialties.includes(specialty)
+                        ? "default"
+                        : "outline"
+                    }
+                    className="cursor-pointer hover:bg-primary/80 transition-colors"
+                    onClick={() => toggleSpecialty(specialty)}
+                  >
+                    {specialty}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            {/* Results Count and Clear Filters */}
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Showing {filteredInstructors.length} of {instructors.length}{" "}
+                instructors
+              </p>
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="text-sm text-primary hover:underline"
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Instructors Grid */}
+      <section className="py-12 sm:py-16">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          {filteredInstructors.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredInstructors.map((instructor) => (
+                <InstructorCard key={instructor.id} instructor={instructor} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <p className="text-lg text-muted-foreground mb-4">
+                No instructors found matching your criteria.
+              </p>
+              <button
+                onClick={clearFilters}
+                className="text-primary hover:underline"
+              >
+                Clear filters and show all instructors
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* CTA Banner */}
+      <CTABanner
+        title={siteContent.ctaBanners.instructors.title}
+        subtitle={siteContent.ctaBanners.instructors.subtitle}
+        primaryCTA={siteContent.ctaBanners.instructors.primaryCTA}
+        variant="blue"
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Built Classes page with search, category/city filters, and sort options
- Built Instructors page with search and clickable specialty tag filters
- Added SEO metadata via layout files for both pages
- Both pages include responsive grids, empty states, and CTA banners

Closes #6

## Test plan
- [ ] Verify Classes page filters work (search, category, city, sort)
- [ ] Verify Instructors page filters work (search, specialty tags)
- [ ] Test "Clear filters" functionality on both pages
- [ ] Confirm empty state displays when no results match
- [ ] Test responsive design on mobile/tablet/desktop
- [ ] Verify SEO metadata appears correctly